### PR TITLE
fix：ログイン処理でaxiosエラーを取得できるように修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/redux-persist": "^4.0.0",
         "@vitejs/plugin-react": "^5.0.4",
         "@vitest/coverage-v8": "^4.0.16",
+        "baseline-browser-mapping": "^2.9.19",
         "eslint": "^9.36.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.22",
@@ -2476,9 +2477,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.25",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz",
-      "integrity": "sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==",
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "@types/redux-persist": "^4.0.0",
         "@vitejs/plugin-react": "^5.0.4",
         "@vitest/coverage-v8": "^4.0.16",
-        "baseline-browser-mapping": "^2.9.19",
         "eslint": "^9.36.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.22",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/redux-persist": "^4.0.0",
     "@vitejs/plugin-react": "^5.0.4",
     "@vitest/coverage-v8": "^4.0.16",
+    "baseline-browser-mapping": "^2.9.19",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.22",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@types/redux-persist": "^4.0.0",
     "@vitejs/plugin-react": "^5.0.4",
     "@vitest/coverage-v8": "^4.0.16",
-    "baseline-browser-mapping": "^2.9.19",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.22",

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export const apiClient = axios.create({
-  baseURL: 'http://0.0.0.0:3000/',
+  baseURL: import.meta.env.VITE_API_BASE_URL_RUST,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
@@ -24,7 +24,7 @@ apiClient.interceptors.response.use(
     (error) => {
       if (error.response?.status === 401) {
         sessionStorage.removeItem('token');
-        window.location.href = '/login';
+        globalThis.location.href = '/login';
       }
       return Promise.reject(error);
     });

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,16 +1,16 @@
-import axios from "axios";
+import axios from 'axios';
 
 export const apiClient = axios.create({
-  baseURL: "http://localhost:8080/",
+  baseURL: 'http://0.0.0.0:3000/',
   withCredentials: true,
   headers: {
-    "Content-Type": "application/json",
+    'Content-Type': 'application/json',
   },
   timeout: 10000,
 });
 
 apiClient.interceptors.request.use((config) => {
-  const token = sessionStorage.getItem("token");
+  const token = sessionStorage.getItem('token');
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
@@ -18,14 +18,13 @@ apiClient.interceptors.request.use((config) => {
 });
 
 apiClient.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  (error) => {
-    if (error.response?.status === 401) {
-      sessionStorage.removeItem("token");
-      window.location.href = "/login";
-    }
-    return Promise.reject(error);
-  }
-);
+    (response) => {
+      return response;
+    },
+    (error) => {
+      if (error.response?.status === 401) {
+        sessionStorage.removeItem('token');
+        window.location.href = '/login';
+      }
+      return Promise.reject(error);
+    });

--- a/src/pages/login/login.test.tsx
+++ b/src/pages/login/login.test.tsx
@@ -185,4 +185,57 @@ describe("Login Component", () => {
       expect(store.getState().auth.user).toBe(null); // ストアにユーザー情報が保存されていないことを確認
     });
   });
+
+  it("ログイン失敗時、ホーム画面に遷移せず、ストアにユーザー情報が保存されず、エラーメッセージが表示されることを確認（404エラー）", async () => {
+    const userLogin = userEvent.setup();
+
+    const mockedPost = vi.mocked(apiClient.post);
+
+    mockedPost.mockRejectedValue(
+      new AxiosError("Not Found", "404", undefined, undefined, {
+        status: 404,
+        statusText: "Not Found",
+        headers: {},
+        config: {} as any,
+        data: {
+          responseInfo: {
+            code: "404",
+            message: "Not Found",
+          },
+          data: {
+            userId: "",
+            userName: "",
+            loginCheck: false,
+            message: "ユーザーIDまたはパスワードが正しくありません。",
+          },
+        },
+      } as any)
+    );
+
+    render(
+      <Provider store={store}>
+        <BrowserRouter>
+          <Login />
+        </BrowserRouter>
+      </Provider>
+    );
+
+    await userLogin.type(
+      screen.getByPlaceholderText("ユーザーIDを入力"),
+      "notFoundUser"
+    );
+    await userLogin.type(
+      screen.getByPlaceholderText("パスワードを入力"),
+      "notFoundPassword"
+    );
+    await userLogin.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/login"); // ログインに失敗後、ホーム画面に遷移しないことを確認
+      expect(store.getState().auth.user).toBe(null); // ストアにユーザー情報が保存されていないことを確認
+      expect(
+        screen.getByText("ユーザーIDまたはパスワードが正しくありません。")
+      ).toBeInTheDocument(); // 404エラーメッセージが表示されることを確認
+    });
+  });
 });

--- a/src/pages/login/login.test.tsx
+++ b/src/pages/login/login.test.tsx
@@ -79,7 +79,7 @@ describe("Login Component", () => {
     await userLogin.click(screen.getByRole("button", { name: "ログイン" }));
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe("/home"); // ログイン成功後、ホーム画面に遷移することを確認
+      expect(globalThis.location.pathname).toBe("/home"); // ログイン成功後、ホーム画面に遷移することを確認
       expect(store.getState().auth.user?.userId).toBe("loginSuccessUser");
       expect(store.getState().auth.user?.userName).toBe("loginSuccessUserName");
       expect(store.getState().auth.user?.loginCheck).toBe(true);
@@ -131,7 +131,7 @@ describe("Login Component", () => {
     await userLogin.click(screen.getByRole("button", { name: "ログイン" }));
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe("/login"); // ログインに失敗後、ホーム画面に遷移しないことを確認
+      expect(globalThis.location.pathname).toBe("/login"); // ログインに失敗後、ホーム画面に遷移しないことを確認
       expect(store.getState().auth.user).toBe(null); // ストアにユーザー情報が保存されていないことを確認
     });
   });

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -10,8 +10,7 @@ import { useDispatch } from "react-redux";
 import type { AppDispatch } from "../../store/userInfoStore";
 import { login } from "../../slices/auth/authSlice";
 import Loading from "../loading/loading";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { AxiosError } from "axios";
+import axios from "axios";
 
 function Login() {
   // TODOログイン処理を追加する
@@ -47,7 +46,7 @@ function Login() {
       responseData = UserInfoSchema.safeParse(response);
       // フォームのリセット
       reset();
-      console.log(responseData);
+      // console.log(responseData);
       // レスポンスのsuccessがtrueでなければエラーとする
       if (!responseData.success) {
         console.error("JSON の形式が不正です:", responseData.error);
@@ -74,8 +73,27 @@ function Login() {
           "ログインに失敗しました。ユーザーIDまたはパスワードが正しくありません。"
         );
       }
-    } catch (err: AxiosError | unknown) {
-      if (err instanceof Error) {
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err)) {
+        const errorData = err.response?.data;
+        const parsedError = UserInfoSchema.safeParse(errorData);
+
+        console.debug(errorData);
+
+        if (err.response?.status === 404) {
+          setError(
+            parsedError.success
+              ? parsedError.data.data.message
+              : "ログインに失敗しました。ユーザーIDまたはパスワードが正しくありません。"
+          );
+        } else {
+          setError(
+            parsedError.success
+              ? parsedError.data.data.message
+              : "サーバー内部でエラーが発生しました。"
+          );
+        }
+      } else if (err instanceof Error) {
         setError("サーバー内部でエラーが発生しました。");
       } else {
         setError("サーバー内部でエラーが発生しました。");

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -53,10 +53,10 @@ function Login() {
         setError("サーバーからの応答形式が不正です。再度お試しください。");
         return;
       }
-      // HTTPステータスコードが5xxの場合はエラーとする
+      // レスポンスボディ内の code が5xx系の場合はエラーとする
       if (responseData.data?.responseInfo.code.startsWith("5")) {
         throw new Error(
-          `HTTP error! status: ${responseData.data?.responseInfo.code}`
+          `API response error! code: ${responseData.data?.responseInfo.code}`
         );
       }
       if (responseData.data.data.loginCheck) {
@@ -78,7 +78,9 @@ function Login() {
         const errorData = err.response?.data;
         const parsedError = UserInfoSchema.safeParse(errorData);
 
-        console.debug(errorData);
+        if (import.meta.env.DEV) {
+          console.debug(errorData);
+        }
 
         if (err.response?.status === 404) {
           setError(

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -10,6 +10,7 @@ import { useDispatch } from "react-redux";
 import type { AppDispatch } from "../../store/userInfoStore";
 import { login } from "../../slices/auth/authSlice";
 import Loading from "../loading/loading";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { AxiosError } from "axios";
 
 function Login() {
@@ -47,16 +48,17 @@ function Login() {
       // フォームのリセット
       reset();
       console.log(responseData);
-      // HTTPステータスコードが2xxでない場合はエラーとする
-      if (!responseData.data?.responseInfo.code.startsWith("2")) {
-        throw new Error(
-          `HTTP error! status: ${responseData.data?.responseInfo.code}`
-        );
-      }
+      // レスポンスのsuccessがtrueでなければエラーとする
       if (!responseData.success) {
         console.error("JSON の形式が不正です:", responseData.error);
         setError("サーバーからの応答形式が不正です。再度お試しください。");
         return;
+      }
+      // HTTPステータスコードが5xxの場合はエラーとする
+      if (responseData.data?.responseInfo.code.startsWith("5")) {
+        throw new Error(
+          `HTTP error! status: ${responseData.data?.responseInfo.code}`
+        );
       }
       if (responseData.data.data.loginCheck) {
         dispatch(


### PR DESCRIPTION
# 概要
ログイン処理でaxiosエラーを取得できるように修正

## 背景・目的
<!--
- なぜこの変更が必要なのか
- 関連する課題 / チケット / Issue
-->
- Issue: なし
- ログイン処理でパスワード誤りで該当するユーザーが存在しない場合、apiClientがエラーを取得してPromiseをrejectしてしまう
しかし、catch側の処理を実装していなかったため、エラーハンドリングできていなかった。
今回はユーザーが存在しない場合のハンドリングを追加。

---

# 変更内容
<!-- 実装・修正内容を箇条書きで記載 -->

- login.tsxで、catchに入った時にerrorがaxiosErrorか判定する処理を追加
- axiosErrorの場合は、ステータスコードで分岐し、ハンドリングするように修正

---

# 影響範囲
<!-- 影響が及ぶ箇所にチェック -->

- [x] フロントエンド
- [ ] バックエンド
- [ ] DB / マイグレーション
- [ ] 設定ファイル
- [ ] CI / CD
- [ ] なし（影響範囲限定）

---

# 動作確認
<!-- 実施した確認内容を具体的に -->

- [x] ローカルでの動作確認
- [ ] 単体テスト実行
- [ ] 手動テスト
- [ ] CI通過

### 確認手順
```text
1.
2.
3.
